### PR TITLE
Truncate overlong name and displayName values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Rename `url` to `icon` in `PublicKeyCredentialRpEntity` and ignore its
   content ([#9][])
+- Truncate overlong `name` and `displayName` values for
+  `PublicKeyCredentialEntity` instances ([#30][])
 
 [#9]: https://github.com/solokeys/ctap-types/issues/9
+[#30]: https://github.com/solokeys/fido-authenticator/issues/30
 
 ## [0.1.2] - 2022-03-07
 


### PR DESCRIPTION
Previously, we just returned an error if a name or displayName value for a PublicKeyCredentialEntity was longer than the supported 64 bytes. With this patch, we instead truncate the value at a UTF-8 character boundary.  The logic for determining the truncation point is borrowed from a nightly function from the standard library.

Fixes: https://github.com/Nitrokey/ctap-types/issues/4

Upstream PR: https://github.com/solokeys/ctap-types/pull/12