### PR TITLE
Filter unknown algorithm

### DIFF
--- a/src/ctap2/get_info.rs
+++ b/src/ctap2/get_info.rs
@@ -1,4 +1,4 @@
-use crate::webauthn::PublicKeyCredentialParameters;
+use crate::webauthn::FilteredPublicKeyCredentialParameters;
 use crate::{Bytes, String, Vec};
 use serde::{Deserialize, Serialize};
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
@@ -53,7 +53,7 @@ pub struct Response {
     // 0xA0
     // FIDO_2_1
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub algorithms: Option<Vec<PublicKeyCredentialParameters, 4>>,
+    pub algorithms: Option<FilteredPublicKeyCredentialParameters>,
     // #[serde(skip_serializing_if = "Option::is_none")]
     // pub(crate) algorithms: Option<&'l[u8]>,
 }

--- a/src/ctap2/make_credential.rs
+++ b/src/ctap2/make_credential.rs
@@ -73,8 +73,7 @@ pub struct Request {
     pub client_data_hash: Bytes<32>,
     pub rp: PublicKeyCredentialRpEntity,
     pub user: PublicKeyCredentialUserEntity,
-    // e.g. webauthn.io sends 10
-    pub pub_key_cred_params: Vec<PublicKeyCredentialParameters, 12>,
+    pub pub_key_cred_params: FilteredPublicKeyCredentialParameters,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_list: Option<Vec<PublicKeyCredentialDescriptor, 16>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This commit modifies the way the pub_key_cred_params is parsed to silently drop unknown algorithms. This ensures that the deserialization does not fail if the host sends more than 12 algorithms (as can be the case with Firefox, see https://github.com/Nitrokey/nitrokey-3-firmware/issues/328) , since we know how many algorithms are supported and will therefore be parsed.

Regarding the spec:
>  This member contains information about the desired properties of the credential to be created.
>  The sequence is ordered from most preferred to least preferred.
>  The client makes a best-effort to create the most preferred credential that it can.

Since the behaviour is best-effort, it makes sense to drop unsupported algorithms at serialization.

We could even consider only keeping the first algorithm that it supported since it is the one that will be used.